### PR TITLE
extension: Add initial openvscode-server support

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,5 +9,5 @@
     },
     "plugins": ["@typescript-eslint"],
     "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
-    "ignorePatterns": ["out", "dist", "node_modules", ".vscode-test", "webpack.config.js"]
+    "ignorePatterns": ["out", "dist", "node_modules", ".vscode-test", "webpack.config.js", "openvscode-server-*"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.vscode-test/
 /dist/
 /node_modules/
+/openvscode-server-*
 /out/
 /vscode-trace-server-*.vsix

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,5 @@
 /.vscode-test/
 /dist/
 /node_modules/
+/openvscode-server-*/
 /out/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,6 +8,7 @@
 .vscode/**
 .yarnrc
 node_modules/**
+openvscode-server-*/**
 out/**
 src/**
 webpack.config.js

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Alternatively, launch `Extension Tests` under `Run and Debug`.
 1. After [having built](#build) at least once, run `yarn vsce:package` ([more][vsce]) at will.
 1. [Install][install] the hereby generated `vscode-trace-server-*.vsix` file.
 1. Alternatively, simply launch the packaged extension using `Run Extension`.
+1. Alternatively, see [these steps](#openvscode-server) for an `openvscode-server` deployment.
 1. Through `Command Palette`, the `Trace Server:` start/stop commands should be available.
 
 This extension can be installed in either one (or many) of:
@@ -48,6 +49,22 @@ A nearby [companion extension][vscode-trace-extension] installation renders a `T
 * This is necessary beside uninstalling the extension from the Theia UI, that is.
 * Without this manual extension directory removal, Blueprint won't use the amended version.
 * Stepping the extension version upon an amend or update shouldn't trigger that issue.
+
+### openvscode-server
+
+This may be used if willing to deploy this extension within [openvscode-server][linux].
+
+1. Any local `~/.openvscode-server/` content will be (re)used if existing; remove at will (prior).
+1. Run `yarn openvscode-server:install` to install `openvscode-server` locally, anywhere, once or so.
+1. Run `yarn openvscode-server:start` to start the `openvscode-server` anytime, anywhere installed.
+
+The server options passed through that start command are scripted in [./package.json](package.json).
+
+* Run `yarn openvscode-server:start --help` to [list and show every such option and more][linux].
+* Overall, this extension deployment is therefore virtually possible either locally or remotely.
+* The client companion [vscode-trace-extension][vscode-trace-extension] is installed elsewhere.
+* Thus, `vscode-trace-extension`'s `Trace Server` status bar item gets rendered from that client.
+* Otherwise co-locating these two extensions lend interactions that aren't possible here, currently.
 
 ## Configuration
 
@@ -100,6 +117,7 @@ This extension is currently under [initial development][backlog].
 [guide]: https://code.visualstudio.com/api/get-started/your-first-extension
 [install]: https://code.visualstudio.com/docs/editor/extension-marketplace#_install-from-a-vsix
 [item]: https://github.com/eclipse-cdt-cloud/vscode-trace-extension/pull/120
+[linux]: https://github.com/gitpod-io/openvscode-server#linux
 [markdownlint]: https://open-vsx.org/extension/DavidAnson/vscode-markdownlint
 [matcher]: https://open-vsx.org/extension/amodio/tsl-problem-matcher
 [prettier]: https://open-vsx.org/extension/esbenp/prettier-vscode

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "VsCode extension for executing a trace server",
     "version": "0.1.0",
     "engines": {
-        "vscode": "^1.78.0"
+        "vscode": "^1.77.3"
     },
     "publisher": "tracecompass-community",
     "categories": [
@@ -57,7 +57,9 @@
         "watch-tests": "tsc -p . -w --outDir out",
         "pretest": "yarn run compile-tests && yarn run compile && yarn run lint",
         "lint": "eslint src --ext ts",
-        "test": "node ./out/test/runTest.js"
+        "test": "node ./out/test/runTest.js",
+        "openvscode-server:install": "curl -L -o openvscode-server-v1.77.3-linux-x64.tar.gz https://github.com/gitpod-io/openvscode-server/releases/download/openvscode-server-v1.77.3/openvscode-server-v1.77.3-linux-x64.tar.gz && tar -xf openvscode-server-v1.77.3-linux-x64.tar.gz",
+        "openvscode-server:start": "cd openvscode-server-v1.77.3-linux-x64/bin && ./openvscode-server --without-connection-token --telemetry-level off --install-extension $INIT_CWD/vscode-trace-server-0.1.0.vsix --start-server"
     },
     "dependencies": {
         "tree-kill": "^1.2.2",
@@ -67,7 +69,7 @@
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",
-        "@types/vscode": "^1.78.0",
+        "@types/vscode": "^1.77.3",
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
         "@vscode/test-electron": "^2.3.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
         "strict": true,
         "esModuleInterop": true
     },
-    "exclude": ["node_modules", ".vscode-test"]
+    "exclude": ["node_modules", ".vscode-test", "openvscode-server-*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,10 +205,10 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz"
   integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
 
-"@types/vscode@^1.78.0":
-  version "1.78.0"
-  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.78.0.tgz"
-  integrity sha512-LJZIJpPvKJ0HVQDqfOy6W4sNKUBBwyDu1Bs8chHBZOe9MNuKTJtidgZ2bqjhmmWpUb0TIIqv47BFUcVmAsgaVA==
+"@types/vscode@^1.77.3":
+  version "1.78.1"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.78.1.tgz#027dba038c9e4c3f8e83570e1494aab679030485"
+  integrity sha512-wEA+54axejHu7DhcUfnFBan1IqFD1gBDxAFz8LoX06NbNDMRJv/T6OGthOs52yZccasKfN588EyffHWABkR0fg==
 
 "@typescript-eslint/eslint-plugin@^5.59.1":
   version "5.59.5"


### PR DESCRIPTION
Document everything that is currently known about this introduction, in README as usual for this extension.
- Main goal being, to be able to remotely deploy this extension, alongside still locally too.

Downgrade the `vscode` version from `1.78.0` to `1.77.3`, the latter being the currently latest stable (`Verified`, [1]) one for this server integration.
- This is because [1]'s version and this `vscode` version have to align, in order for `openvscode-server` to work.
- Contributes to fixing the foreign (companion's) Issue [2], below.

[1]https://github.com/gitpod-io/openvscode-server/tags
[2]https://github.com/eclipse-cdt-cloud/vscode-trace-extension/issues/15

Signed-off-by: Marco Miller <marco.miller@ericsson.com>