### PR TITLE
Make start and stop commands real async commands

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,15 +19,15 @@ export function deactivate() {
 }
 
 function registerStopOrReset(context: vscode.ExtensionContext | undefined): vscode.Disposable {
-    return vscode.commands.registerCommand(stopOrReset, () => {
-        return server.stopOrReset(context);
+    return vscode.commands.registerCommand(stopOrReset, async () => {
+        await server.stopOrReset(context);
     });
 }
 export const registerStopOrReset_test = registerStopOrReset;
 
 function registerStartIfStopped(context: vscode.ExtensionContext | undefined): vscode.Disposable {
-    return vscode.commands.registerCommand(startIfStopped, () => {
-        server.startIfStopped(context);
+    return vscode.commands.registerCommand(startIfStopped, async () => {
+        await server.startIfStopped(context);
     });
 }
 export const registerStartIfStopped_test = registerStartIfStopped;


### PR DESCRIPTION
With this the execution can be awaited for when executing the commands programmatically before continuing.

This is needed for https://github.com/eclipse-cdt-cloud/vscode-trace-extension/pull/155.

Signed-off-by: Bernd Hufmann <bernd.hufmann@ericsson.com>