### PR TITLE
Remove .git directory from packaged plugin

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,7 @@
 **/*.ts
 **/.eslintrc.json
 **/tsconfig.json
+.git
 .gitignore
 .vscode-test/**
 .vscode/**


### PR DESCRIPTION
At present, running the `yarn vsce:package` script in this repo's `package.json` will create a packaged extension that includes the contents of the `.git` folder.

This PR ensures that `.git` is not included in the packaged plugin.

## To test
1. Run `yarn` and `yarn vsce:package`
2. Unzip the built plugin
3. Observe that there is no `.git` folder in the contents.

Alternatively:
1. Run `yarn vsce ls` and see that the result does not include `.git` (on `main`, it does).