### PR TITLE
Fix stopping trace server during shutdown

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,8 +14,8 @@ export function activate(context: vscode.ExtensionContext) {
     activation = context;
 }
 
-export function deactivate() {
-    server.stopOrReset(activation);
+export async function deactivate() {
+    await server.shutdown(activation);
 }
 
 function registerStopOrReset(context: vscode.ExtensionContext | undefined): vscode.Disposable {


### PR DESCRIPTION
During shutdown of vscode and the triggered deactivation of the extension, the vscode services are not reliably available anymore. Hence the killing of the trace server process has to happen in the same thread of execution. The trace server is killed by calling  `treeKill` because the Trace Compass server spawns 2 processes. `treeKill` collects all processes starting from the parent PID using operation system specific calls. Once all PIDs are collected, each one is killed one by one asynchronously. The main execution continues and the callbacks to kill is not handled anymore. This is why the server continues. 

This patch calls `treeKill` right away and adds a delay before returning the shutdown procedure. This delay gives the `treeKill` execution time to finish.

Fixes #13