### PR TITLE
Register to vscode-trace-extension as a trace server contributor

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
         "type": "git",
         "url": "https://github.com/eclipse-cdt-cloud/vscode-trace-server.git"
     },
-    "activationEvents": [],
+    "activationEvents": [
+        "onStartupFinished"
+    ],
     "main": "./dist/extension.js",
     "extensionKind": [
         "workspace"
@@ -83,5 +85,8 @@
         "typescript": "^5.0.4",
         "webpack": "^5.81.0",
         "webpack-cli": "^5.0.2"
-    }
+    },
+    "extensionDependencies": [
+        "eclipse-cdt.vscode-trace-extension"
+    ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,15 @@ const startIfStopped = extensionId + '.start-if-stopped';
 let activation: vscode.ExtensionContext;
 
 export function activate(context: vscode.ExtensionContext) {
+    const vscodeTraceExtension = vscode.extensions.getExtension('eclipse-cdt.vscode-trace-extension');
+    if (vscodeTraceExtension) {
+        const api = vscodeTraceExtension.exports;
+        const contributor = {
+            startServer: () => server.startIfStopped(context),
+            stopServer: () => server.stopOrReset(context)
+        }
+        api.addTraceServerContributor(contributor);
+    }
     context.subscriptions.push(registerStopOrReset(context));
     context.subscriptions.push(registerStartIfStopped(context));
     activation = context;


### PR DESCRIPTION
Activate the extension on the "onStartupFinished" activation event. At activation, register as a trace server contributor to the vscode-trace-extension, as the default wildcard contributor by not providing any isApplicable method implementation.