### PR TITLE
Add 3PP license check as part of PR CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [16.x]
+
+    steps:
+    - name: install dependencies on ubuntu
+      if: startsWith(matrix.os,'ubuntu')
+      run: |
+        sudo apt install -y make gcc pkg-config build-essential libx11-dev libxkbfile-dev
+
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Cache node_modules with yarn
+      uses: actions/cache@v2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+
+    - run: yarn --frozen-lockfile
+
+  tests:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: yarn
+    - name: Run tests
+      uses: coactions/setup-xvfb@v1
+      with:
+        run: yarn test
+
+  code-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out Git repository
+      uses: actions/checkout@v2
+
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '16'
+
+    # ESLint and Prettier must be in `package.json`
+    - run: yarn --frozen-lockfile --ignore-scripts
+
+    - run: yarn lint

--- a/.github/workflows/license-check-workflow.yml
+++ b/.github/workflows/license-check-workflow.yml
@@ -1,0 +1,52 @@
+name: 3PP License Check
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 4 * * *' # Runs every day at 4am: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule
+
+jobs:
+
+  License-check:
+    name: 3PP License Check using dash-licenses
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node: [18]
+        java: [11]
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Use Java ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: ${{ matrix.java }}
+
+      - name: Run dash-licenses
+        shell: bash
+        run: |
+          yarn --frozen-lockfile
+          yarn license:check
+        env:
+          DASH_TOKEN: ${{ secrets.DASH_LICENSES_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /node_modules/
 /out/
 /vscode-trace-server-*.vsix
+license-check-summary.txt*

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This README is the usual entry point for documenting this extension.
 Run `yarn`, which should automatically include `yarn install`.
 
 * This extension is bundled using `webpack`, originally based on [the guide][guide].
-* There is no support yet for any automated CI on GitHub; planned for though.
+* There is only a modest automated CI test suite being run on GitHub
 
 ## Test
 

--- a/configs/license-check-config.json
+++ b/configs/license-check-config.json
@@ -1,0 +1,8 @@
+{
+    "project": "ecd.cdt-cloud",
+    "review": false,
+    "inputFile": "yarn.lock",
+    "batch": 50,
+    "timeout": 200,
+    "summary": "license-check-summary.txt"
+}

--- a/package.json
+++ b/package.json
@@ -57,13 +57,16 @@
         "watch-tests": "tsc -p . -w --outDir out",
         "pretest": "yarn run compile-tests && yarn run compile && yarn run lint",
         "lint": "eslint src --ext ts",
-        "test": "node ./out/test/runTest.js"
+        "test": "node ./out/test/runTest.js",
+        "license:check": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
+        "license:check:review": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review"
     },
     "dependencies": {
         "tree-kill": "^1.2.2",
         "tsp-typescript-client": "next"
     },
     "devDependencies": {
+        "@eclipse-dash/nodejs-wrapper": "^0.0.1",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "16.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@eclipse-dash/nodejs-wrapper@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-dash/nodejs-wrapper/-/nodejs-wrapper-0.0.1.tgz#f2629671cf090a84c4d69a8fec42f198e583d103"
+  integrity sha512-Rkk8O8hEVi/+LC/co7ly1zGLVwCNJG3yPbalsz1FHAqk6WZyEaWNf29EX6jz4vTfR5wpv2xAfF2yokKuStiOdA==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz"


### PR DESCRIPTION
Depends on [dash-licenses nodejs-wrapper](https://github.com/eclipse-dash/nodejs-wrapper) being released on npm. ([ongoing](https://github.com/eclipse-dash/nodejs-wrapper/pull/2)). 

However, I went ahead and published a `v0.0.1` so we can start using it immediately - the plan is to catch-up with the PR above and a small subsequent one that will create the GitHub release for this version. 

Also adds a minimalist build/test workflow that runs existing tests. For now it will be only informational, letting the committers know that some 3PPs look suspicious. Any committer can then run the dash-licenses wrapper locally to automatically create the required IP ticket(s) - see commit message for more details.

Closes #17