### PR TITLE
Release v0.2.1

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.2.0
+tag: v0.2.1
 
 commitInclude:
   parentOfMergeCommit: true

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-trace-server",
     "displayName": "VSCode Trace Server",
     "description": "Companion extension to the Trace Viewer for VSCode, that makes it easier to start/stop a local trace server",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "license": "MIT",
     "engines": {
         "vscode": "^1.78.0"


### PR DESCRIPTION
Trigger release v0.2.1. If everything goes well, this time the extension should be published to the Visual Studio Markerplace, in addition to public OpenVSX (open-vsx.org).