### PR TITLE
[TENTATIVE - DO NOT MERGE] Adjust to renaming of vscode trace extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,6 @@
         "webpack-cli": "^5.0.2"
     },
     "extensionDependencies": [
-        "eclipse-cdt.vscode-trace-extension"
+        "eclipse-cdt.vscode-trace-viewer"
     ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ const startIfStopped = extensionId + '.start-if-stopped';
 let activation: vscode.ExtensionContext;
 
 export function activate(context: vscode.ExtensionContext) {
-    const vscodeTraceExtension = vscode.extensions.getExtension('eclipse-cdt.vscode-trace-extension');
+    const vscodeTraceExtension = vscode.extensions.getExtension('eclipse-cdt.vscode-trace-viewer');
     if (vscodeTraceExtension) {
         const api = vscodeTraceExtension.exports;
         const contributor = {


### PR DESCRIPTION
Note: this is tentative for now. See:
https://github.com/eclipse-cdt-cloud/vscode-trace-extension/pull/213

The trace viewer extension (vscode-trace-extension) might need to be renamed, tentatively to "vscode-trace-viewer", in orfer for it to be publishable to the Visual Studio Marketplace. If that happens, references to the extension, will neeed to follow suite.

This extension here uses the API offered by the trace viewer extension, and would eventuality will need to refer to it using the new name.