### PR TITLE
check for trace server URL ending with slash

### DIFF
--- a/src/trace-server.ts
+++ b/src/trace-server.ts
@@ -154,7 +154,8 @@ export class TraceServer {
 
     private getServerUrl() {
         const from = this.getClientSettings();
-        return this.getUrl(from) + '/' + this.getApiPath(from);
+        const baseUrl = this.getUrl(from);
+        return baseUrl.endsWith('/') ? baseUrl + this.getApiPath(from) : baseUrl + '/' + this.getApiPath(from);
     }
 
     private async waitFor(context: vscode.ExtensionContext | undefined) {


### PR DESCRIPTION
Fixes #37

With this commit, the trace server extension will check if the base trace server URL, defined as a preference, ends with a slash. If that's the case, it will be used to compose the TSP endpoint URL, if not it will be added.