### PR TITLE
Release v0.2.4 (Patch)

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,4 +1,4 @@
-tag: v0.2.3
+tag: v0.2.4
 
 commitInclude:
   parentOfMergeCommit: true

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.3",
+    "version": "0.2.4",
     "npmClient": "yarn",
     "command": {
         "run": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-trace-server",
     "displayName": "VSCode Trace Server",
     "description": "Companion extension to the Trace Viewer for VSCode, that makes it easier to start/stop a local trace server",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "license": "MIT",
     "engines": {
         "vscode": "^1.78.0"


### PR DESCRIPTION
Publish a new version of the "Trace Server for VSCode", that benefits from the recently updated dependencies (yarn upgrade), including a fixed `webpack` package that not subject to a recently discovered vulnerability.