### PR TITLE
Use machine scope for traceserver path setting (to omit from "setting…

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
             "properties": {
                 "trace-server.traceserver.path": {
                     "type": "string",
+                    "scope" : "machine",
                     "default": "/usr/bin/tracecompass-server",
                     "description": "Enter the trace server's binary path, executable included. Eg: /usr/bin/tracecompass-server."
                 },


### PR DESCRIPTION
…s sync").

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-server/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

This change sets the scope of the traceserver path setting to be "machine" scope rather than application scope.  This omits the setting from the "settings sync" feature of VSCode (when the settings sync is turned on).  This prevents, for instance, changes to user's traceserver path on Windows from affecting their Linux settings, and vice-versa, so that user can have settings sync turned on, and keep the different traceserver paths on different machines/OSes from clobbering each other.

### How to test

Turn on settings sync from VSCode on a Linux machine and a Windows machine, vary the traceserver path on both machines, and observe that the paths can be varied independently without influencing the corresponding setting on other machine/OS.

### Follow-ups

None identified.

### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
