### PR TITLE
Enhance trace server argument parsing to allow system property values containing whitespace to be passed to JVM

### DIFF
--- a/src/argparse.ts
+++ b/src/argparse.ts
@@ -1,0 +1,97 @@
+class ArgExtractor {
+    argsStr: string;
+    index: number;
+
+    constructor(argsStr: string) {
+        this.argsStr = argsStr;
+        this.index = 0;
+        this.skipWhitespace();
+    }
+
+    isEos(): boolean {
+        const result = this.index >= this.argsStr.length;
+        return result;
+    }
+
+    private isWhitespace(ch: string) {
+        const result = /\s/g.test(ch);
+        return result;
+    }
+
+    private consumeChar(): void {
+        this.index++;
+    }
+
+    private peekChar(): string {
+        return this.argsStr[this.index];
+    }
+
+    private nextChar(): string {
+        return this.argsStr[this.index++];
+    }
+
+    private skipWhitespace(): void {
+        let char = this.peekChar();
+        while (this.index < this.argsStr.length && this.isWhitespace(char)) {
+            this.consumeChar();
+            char = this.peekChar();
+        }
+    }
+
+    next(): string {
+        let arg = '';
+        let inQuotedString = false;
+
+        const handleWhitespace = (char: string): boolean => {
+            if (inQuotedString) {
+                arg = arg.concat(char);
+                return false;
+            } else {
+                this.skipWhitespace();
+                return true;
+            }
+        };
+
+        const handleDoubleQuote = () => {
+            if (inQuotedString) {
+                const peek = this.peekChar();
+                if (peek == '"') {
+                    // literal quote
+                    this.consumeChar();
+                    arg = arg.concat(peek);
+                } else {
+                    // end of quotation; just consume character without adding literally to arg
+                    inQuotedString = false;                    
+                }
+            } else {
+                // open double quotation
+                inQuotedString = true;
+            }
+        };
+
+        while (!this.isEos()) {
+            const char = this.nextChar();
+            if (this.isWhitespace(char)) {
+                if (handleWhitespace(char)) {
+                    break;
+                }
+            } else if (char == '"') {
+                handleDoubleQuote();
+            } else {
+                // some other character other than whitespace or quotes or escape character; include in arg and continue
+                arg = arg.concat(char);
+            }
+        }
+        return arg;
+    }
+}
+
+export function parseArgs(argsStr: string): string[] {
+    const extractor = new ArgExtractor(argsStr);
+    const result = [];
+    while (!extractor.isEos()) {
+        const arg = extractor.next();
+        result.push(arg);
+    }
+    return result;
+}

--- a/src/test/suite/argparse.test.ts
+++ b/src/test/suite/argparse.test.ts
@@ -5,30 +5,30 @@ import * as argparse from '../../argparse';
 suite('Argument Parser Test Suite', () => {
     vscode.window.showInformationMessage('Start argument parser tests.');
 
-    const prefix = 'Argument parser should be able to handle argument strings ';
+    const prefix = 'Argument parser should be able to ';
 
-    test(prefix + 'that do not use quoting', () => {
+    test(prefix + 'handle argument strings that do not use quoting', () => {
         const args = argparse.parseArgs('-vmargs -Dsome.property=value_without_spaces');
         assert.deepEqual(args, ['-vmargs', '-Dsome.property=value_without_spaces']);
     });
 
-    test(prefix + 'that have extra whitespace between arguments', () => {
+    test(prefix + 'handle argument strings that have extra whitespace between arguments', () => {
         const args = argparse.parseArgs('   -vmargs    -Dsome.property=value_without_spaces \t  ');
         assert.deepEqual(args, ['-vmargs', '-Dsome.property=value_without_spaces']);
     });
 
-    test(prefix + 'that use quoting', () => {
+    test(prefix + 'handle argument strings that use quoting', () => {
         const args = argparse.parseArgs('   -vmargs    -Dsome.property="value with spaces" \t  ');
         assert.deepEqual(args, ['-vmargs', '-Dsome.property=value with spaces']);
-    });
-
-    test(prefix + 'that use quotes with embedded literal quotes (using a sequence of 2 consecutive quotes)', () => {
-        const args = argparse.parseArgs('   -vmargs    -Dsome.property="""in literal quotes""" \t  ');
-        assert.deepEqual(args, ['-vmargs', '-Dsome.property="in literal quotes"']);
     });
 
     test(prefix + 'recognize non-nested consecutive quotes as an empty string', () => {
         const parsed = argparse.parseArgs('empty_value=""');
         assert.deepEqual(parsed, ['empty_value=']);
+    });
+
+    test(prefix + 'recognize nested consecutive quotes as a literal quote character', () => {
+        const args = argparse.parseArgs('   -vmargs    -Dsome.property="""in literal quotes""" \t  ');
+        assert.deepEqual(args, ['-vmargs', '-Dsome.property="in literal quotes"']);
     });
 });

--- a/src/test/suite/argparse.test.ts
+++ b/src/test/suite/argparse.test.ts
@@ -1,0 +1,34 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as argparse from '../../argparse';
+
+suite('Argument Parser Test Suite', () => {
+    vscode.window.showInformationMessage('Start argument parser tests.');
+
+    const prefix = 'Argument parser should be able to handle argument strings ';
+
+    test(prefix + 'that do not use quoting', () => {
+        const args = argparse.parseArgs('-vmargs -Dsome.property=value_without_spaces');
+        assert.deepEqual(args, ['-vmargs', '-Dsome.property=value_without_spaces']);
+    });
+
+    test(prefix + 'that have extra whitespace between arguments', () => {
+        const args = argparse.parseArgs('   -vmargs    -Dsome.property=value_without_spaces \t  ');
+        assert.deepEqual(args, ['-vmargs', '-Dsome.property=value_without_spaces']);
+    });
+
+    test(prefix + 'that use quoting', () => {
+        const args = argparse.parseArgs('   -vmargs    -Dsome.property="value with spaces" \t  ');
+        assert.deepEqual(args, ['-vmargs', '-Dsome.property=value with spaces']);
+    });
+
+    test(prefix + 'that use quotes with embedded literal quotes (using a sequence of 2 consecutive quotes)', () => {
+        const args = argparse.parseArgs('   -vmargs    -Dsome.property="""in literal quotes""" \t  ');
+        assert.deepEqual(args, ['-vmargs', '-Dsome.property="in literal quotes"']);
+    });
+
+    test(prefix + 'recognize non-nested consecutive quotes as an empty string', () => {
+        const parsed = argparse.parseArgs('empty_value=""');
+        assert.deepEqual(parsed, ['empty_value=']);
+    });
+});

--- a/src/test/suite/trace-server.test.ts
+++ b/src/test/suite/trace-server.test.ts
@@ -16,7 +16,7 @@ suite('TraceServer Test Suite', () => {
 
     test(prefix + 'arguments', () => {
         const args = server.getArgs_test(from);
-        assert.deepEqual(args, ['']);
+        assert.deepEqual(args, []);
     });
 
     test(prefix + 'url', () => {

--- a/src/trace-server.ts
+++ b/src/trace-server.ts
@@ -2,6 +2,7 @@ import { ChildProcess, spawn } from 'child_process';
 import { TspClient } from 'tsp-typescript-client/lib/protocol/tsp-client';
 import treeKill from 'tree-kill';
 import * as vscode from 'vscode';
+import { parseArgs } from './argparse';
 
 // Based on github.com/eclipse-cdt-cloud/vscode-trace-extension/blob/master/vscode-trace-extension/package.json
 // -for naming consistency purposes across sibling extensions/settings:
@@ -122,7 +123,7 @@ export class TraceServer {
         if (!args) {
             args = '';
         }
-        return args.split(' ');
+        return parseArgs(args);
     }
     getArgs_test = this.getArgs;
 


### PR DESCRIPTION
This patch is intended to allow JVM system property values containing whitespace to be passed successfully through to the JVM that the trace server executable spawns.   

### What it does

Consider an example where we want to use a command line argument to ask trace server to spawn its JVM in such a way that a system property gets defined, whose value is a string with embedded whitespace:

-vmargs -Dsome.property="some value with spaces"

On current main branch, this doesn't seem to work, because of the way the VSCode field is parsed into an array of strings for subsequent call to child_process.spawn.  The parsing on main branch currently splits the string at every space character.

This patch intends to enhance the parsing scheme to allow double quotes (as meta-characters) to be usable for this use case.

A new unit test file that runs under "yarn test" is part of this patch.

### How to test

Try this procedure on both the current main branch, and also on the branch of this pull request, and compare/contrast the observed results:

1) Place this string in the trace server arguments field within VSCode settings:

-vmargs -Dsome.property="some value with spaces"

2) Drive the vscode-trace-server extension in such a way that it spawns a new trace server instance.  Verify that the trace server instance is indeed running, and verify (e.g. using Linux ps command or via /proc file system) the command line of the running process includes the fragment:

-Dsome.property=some value with spaces

Also run "yarn test" to verify all of those tests are passing.

### Follow-ups

None identified.

### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
