### PR TITLE
Rename command start and stop commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note: this extension is only aware of a running trace server if it started of he
 
 ### Stopping the Trace Server
 
-Use the `Trace Server: stop or reset` command to kill both processes, stopping the server. If the server was stopped outside the application (e.g. killed), using this command will reset the known `pid` and allow to start it again.
+Use the `Trace Server: Stop or Reset` command to kill both processes, stopping the server. If the server was stopped outside the application (e.g. killed), using this command will reset the known `pid` and allow to start it again.
 
 Note that exiting the application should automatically stop the started server if started through it. 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If this extension is configured correctly, it will automatically start the trace
 
 Manual start:
 
-Use the `Trace Server: start (if stopped)` command to launch the trace server instance. The latter should be made of two related processes; to find them, `grep` for `tracecompass` or the like.
+Use the `Trace Server: Start` command to launch the trace server instance. The latter should be made of two related processes; to find them, `grep` for `tracecompass` or the like.
 
 Note: this extension is only aware of a running trace server if it started of helped start it, as per above. It will not know if you started the server on the CLI or outside using other means than described above.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "commands": [
             {
                 "command": "vscode-trace-server.stop-or-reset",
-                "title": "Trace Server: stop or reset"
+                "title": "Trace Server: Stop or Reset"
             },
             {
                 "command": "vscode-trace-server.start-if-stopped",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
             },
             {
                 "command": "vscode-trace-server.start-if-stopped",
-                "title": "Trace Server: start (if stopped)"
+                "title": "Trace Server: Start"
             }
         ],
         "configuration": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-cdt-cloud/vscode-trace-server/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

### What it does

- Rename start command to `Trace Server: Start`
Fixes #15
- Rename `Trace Server: stop or reset` to `Trace Server: Stop or Reset`
This is more consistent to other command in VsCode.

<!-- Include relevant issues and describe how they are addressed. -->

### How to test

Run extension and verify the command name. Verify commands still work.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the instructions in this template
